### PR TITLE
Fixed typo in DELETE CORS

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ var status = require('./routes/status');
 var app = express();
 var corsOptions = {
     origin: '*',
-    methods: ['GET', 'PUT', 'POST', 'PATCH', 'DELETEx', 'UPDATE'],
+    methods: ['GET', 'PUT', 'POST', 'PATCH', 'DELETE', 'UPDATE'],
     credentials: true
 };
 


### PR DESCRIPTION
Il y avait une tyope dans les corsOptions qui empêchaient l'utilisation de la méthode http DELETE
