### PR TITLE
Add playlist on the return of remove track on playlist

### DIFF
--- a/routes/playlists.js
+++ b/routes/playlists.js
@@ -85,7 +85,7 @@ exports.removeTrackFromPlaylist = function (req, res) {
                 if (trackToRemove) {
                     trackToRemove.remove();
                     playlist.save();
-                    res.status(200).send();
+                    res.status(200).send(playlist);
                 } else {
                     res.status(404).send({
                         errorCode: 'TRACK_NOT_FOUND',


### PR DESCRIPTION
Si aucun élément n'est retourné, même pas "{}" il est alors impossible de faire des callback sur le destroy d'une track.
