### PR TITLE
Fix bug  when user not found => unfollow

### DIFF
--- a/routes/user.js
+++ b/routes/user.js
@@ -127,11 +127,11 @@ exports.unfollow = function (req, res) {
     var userId = req.params.id;
     if (req.user.isFollowingUser(userId)) {
         req.user.unfollow(userId);
+        res.status(200).send(req.user.toDTO(true));
     } else {
         res.status(404).send({
             errorCode: 'USER_NOT_FOUND',
             message: 'User does not follow user with id ' + req.body.id
         });
     }
-    res.status(200).send(req.user.toDTO(true));
 };


### PR DESCRIPTION
error: Can't set headers after they are sent. at ServerResponse.OutgoingMessage.setHeader (_http_outgoing.js:335:11) at ServerResponse.header (/home/ubeat/UBeat/node_modules/express/lib/response.js:767:10) at ServerResponse.send (/home/ubeat/UBeat/node_modules/express/lib/response.js:170:12) at ServerResponse.json (/home/ubeat/UBeat/node_modules/express/lib/response.js:267:15) at ServerResponse.send (/home/ubeat/UBeat/node_modules/express/lib/response.js:158:21) at exports.unfollow (/home/ubeat/UBeat/routes/user.js:136:21) at Layer.handle [as handle_request] (/home/ubeat/UBeat/node_modules/express/lib/router/layer.js:95:5) at next (/home/ubeat/UBeat/node_modules/express/lib/router/route.js:137:13) at /home/ubeat/UBeat/middleware/authentication.js:23:32 at /home/ubeat/UBeat/node_modules/mongoose/lib/model.js:3932:16 at /home/ubeat/UBeat/node_modules/mongoose/lib/query.js:2007:28 at nextTickCallbackWith0Args (node.js:419:9) at process._tickCallback (node.js:348:13)