### PR TITLE
Fix mongoUri when not using environment variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,8 @@ const cors = require('cors')
 const passport = require('passport')
 
 const mongoose = require('mongoose')
-const mongoUri =
-  process.env.MONGOLAB_URI || `mongodb://${process.env.DATABASE_URL}` || 'mongodb://localhost/ubeat'
+const mongoUriFromEnv = process.env.DATABASE_URL ? `mongodb://${process.env.DATABASE_URL}` : process.env.MONGOLAB_URI;
+const mongoUri = mongoUriFromEnv || 'mongodb://localhost/ubeat';
 mongoose.connect(
   mongoUri,
   {

--- a/index.js
+++ b/index.js
@@ -8,8 +8,8 @@ const cors = require('cors')
 const passport = require('passport')
 
 const mongoose = require('mongoose')
-const mongoUriFromEnv = process.env.DATABASE_URL ? `mongodb://${process.env.DATABASE_URL}` : process.env.MONGOLAB_URI;
-const mongoUri = mongoUriFromEnv || 'mongodb://localhost/ubeat';
+const mongoUriFromEnv = process.env.DATABASE_URL ? `mongodb://${process.env.DATABASE_URL}` : process.env.MONGOLAB_URI
+const mongoUri = mongoUriFromEnv || 'mongodb://localhost/ubeat'
 mongoose.connect(
   mongoUri,
   {


### PR DESCRIPTION
The uri was fallbacking to `mongodb://undefined` instead of `mongodb://localhost/ubeat` when `MONGOLAB_URI` or `DATABASE_URL` environment variables were not set.

**Stack trace** 
```(node:15364) UnhandledPromiseRejectionWarning: MongoNetworkError: failed to connect to server [undefined:27017] on first connect [MongoNetworkError: getaddrinfo ENOTFOUND undefined undefined:27017]```