### PR TITLE
Fixed a bug when creating a new playlist

### DIFF
--- a/routes/playlists.js
+++ b/routes/playlists.js
@@ -20,11 +20,12 @@ exports.createPlaylist = async function(req, res) {
 
 // Unsecure (Will be removed after release 2)
 exports.createPlaylistUnsecure = async function(req, res) {
-  const playlist = new Playlist({
-    name: req.body.name,
-    owner: req.body.owner
-  })
-  try {
+  try { 
+    const user = await User.findOne({'email' : req.body.owner});
+    const playlist = new Playlist({
+      name: req.body.name,
+      owner: user.toJSON()
+    })
     await playlist.save()
     res.status(201).send(playlist)
   } catch (err) {


### PR DESCRIPTION
When creating a new playlist on the unsecured route, the owner field was missing because `req.body.owner` wasn't a JSON object as expected by the playlist schema. 

EDIT:

Before my modifications, when we do a POST and then a GET on `/unsecure/playlists`, the response received looks like this:
```
{
        "name": "Team 24 Playlis 2",
        "tracks": [],
        "id": "5bc657d173971b29c5bf7dd6"
}
```
Instead, according to the playlist schema (`models/playlist.js`), I believe that we should receive a response like below, because otherwise it seems impossible to know which playlist belongs to which user.
```
{
        "owner": {
            "name": "Team 24",
            "email": "team24@gmail.com",
            "id": "5bc64db9c1f1f4210cff797d"
        },
        "name": "Team 24 Playlist",
        "tracks": [],
        "id": "5bc65124392f11278a62e51e"
}
```